### PR TITLE
IMP Avoid double oorq calls

### DIFF
--- a/poweremail_oorq/poweremail_send_wizard.py
+++ b/poweremail_oorq/poweremail_send_wizard.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from itertools import chain
 from osv import osv
+from rq import get_current_job
 from oorq.decorators import job
 from oorq.oorq import JobsPool
 from tools import config
@@ -11,9 +12,7 @@ class PoweremailSendWizard(osv.osv_memory):
     _inherit = 'poweremail.send.wizard'
 
     def save_to_mailbox(self, cursor, uid, ids, context=None):
-        if context is None:
-            context = {}
-        if context.get('from_oorq', False):
+        if get_current_job():
             return super(PoweremailSendWizard,
                          self).save_to_mailbox(cursor, uid, ids,
                                                context=context)


### PR DESCRIPTION
Now if context has set from_oorq to True the jobs are NOT callend in background. This avoid a bug if a background process call save_to_mailbox function.
