### PR TITLE
preprocess attachments id in order to follow proper method to create many2many field

### DIFF
--- a/poweremail_oorq/poweremail_send_wizard.py
+++ b/poweremail_oorq/poweremail_send_wizard.py
@@ -71,6 +71,10 @@ class PoweremailSendWizard(osv.osv_memory):
         del ctx['screen_vals']
         if not screen_vals:
             raise Exception("No screen_vals found in the context!")
+        attach_ids = screen_vals.get('attachment_ids', [])
+        if attach_ids:
+            screen_vals['attachment_ids'] = [(6, 0, attach_ids)]
+
         wiz_id = self.create(cursor, uid, screen_vals, ctx)
         mail_ids = super(PoweremailSendWizard,
                          self).save_to_mailbox(cursor, uid, [wiz_id], ctx)


### PR DESCRIPTION
RQ worker tries to create a new wizard using data from job in queue. Attachments_id is retrieved as list of id (many2many) but different format is required. Added attachments_id preprocessing in order to fulfill ORM many2many requirements.