### PR TITLE
NEW Save to Mailbox ASYNC

### DIFF
--- a/poweremail_oorq/__terp__.py
+++ b/poweremail_oorq/__terp__.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 {
-  "name": "Poweremail OORQ",
-  "description": """Poweremail using OORQ""",
-  "version": "0.2.4",
-  "author": "GISCE",
-  "category": "GISCEMaster",
-  "depends": ['base', 'poweremail', 'oorq'],
-  "init_xml": [],
-  "demo_xml": [],
-  "update_xml": [],
-  "active": False,
-  "installable": True
+    "name": "Poweremail OORQ",
+    "description": """Poweremail using OORQ""",
+    "version": "0.2.4",
+    "author": "GISCE",
+    "category": "GISCEMaster",
+    "depends": ['base', 'poweremail', 'oorq'],
+    "init_xml": [],
+    "demo_xml": [],
+    "update_xml": [],
+    "active": False,
+    "installable": True
 }

--- a/poweremail_oorq/poweremail_send_wizard.py
+++ b/poweremail_oorq/poweremail_send_wizard.py
@@ -58,6 +58,10 @@ class PoweremailSendWizard(osv.osv_memory):
             j_pool.add_job(job)
             if 'screen_vals' in ctx:
                 del ctx['screen_vals']
+        # When using `save_async`, it won't join the jobs, so they'll be
+        #    done on background.
+        # The background rendered emails will be added to the folder on
+        #    context and won't be forced into the 'outbox' folder
         if not(context.get('save_async', False)):
             j_pool.join()
             for res_job in j_pool.results.values():
@@ -81,6 +85,7 @@ class PoweremailSendWizard(osv.osv_memory):
         wiz_id = self.create(cursor, uid, screen_vals, ctx)
         mail_ids = super(PoweremailSendWizard,
                          self).save_to_mailbox(cursor, uid, [wiz_id], ctx)
+        # When using `save_async`, we leave the folder as it should be
         if not(context.get('save_async', False)):
             mailbox_obj.write(cursor, uid, mail_ids, {'folder': 'drafts'}, ctx)
         return mail_ids


### PR DESCRIPTION
## PRE

It cannot save ASYNC a group of mailbox using the wizard `poweremail_send_wizard.py` because it does wait to get all the mails created (Job pool join) and returns the data from the mails created to the wizard.

## Work

- [x] ADD `save_async` context var to avoid `JobPool.Join()`
