### PR TITLE
Enable OORQ_ASYNC flag

### DIFF
--- a/poweremail_oorq/poweremail_mailbox.py
+++ b/poweremail_oorq/poweremail_mailbox.py
@@ -2,6 +2,7 @@
 from osv import osv
 from oorq.decorators import job
 from tools import config
+import os
 
 
 class PoweremailMailbox(osv.osv):
@@ -19,6 +20,10 @@ class PoweremailMailbox(osv.osv):
                      self).send_this_mail(cursor, uid, ids, context)
 
     def send_this_mail(self, cursor, uid, ids=None, context=None):
+        if not eval(os.environ.get('OORQ_ASYNC', 1)):
+            return super(PoweremailMailbox, self).send_this_mail(
+                cursor, uid, ids, context=context
+            )
         if not isinstance(ids, (tuple, list)):
             ids = [ids]
         for mail in self.read(cursor, uid, ids, ['priority']):


### PR DESCRIPTION
Siempre se hacía uso de las colas sin importar si se indicaba lo contrario con el _flag_ `OORQ_ASYNC`