### PR TITLE
Add generate_mail in background

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+.idea

--- a/poweremail_oorq/__init__.py
+++ b/poweremail_oorq/__init__.py
@@ -1,2 +1,4 @@
-import poweremail_mailbox
-import poweremail_send_wizard
+from __future__ import absolute_import
+from . import poweremail_mailbox
+from . import poweremail_send_wizard
+from . import poweremail_template

--- a/poweremail_oorq/poweremail_template.py
+++ b/poweremail_oorq/poweremail_template.py
@@ -1,0 +1,31 @@
+from osv import osv
+from tools import config
+from oorq.decorators import job
+
+
+class PoweremailTemplates(osv.osv):
+    _name = 'poweremail.templates'
+    _inherit = 'poweremail.templates'
+
+    @job(queue=config.get('poweremail_render_queue', 'poweremail'), on_commit=True, at_front=True)
+    def generate_mail_in_background_at_front(self, cursor, uid, template_id, ids, context=None):
+        return super(PoweremailTemplates, self).generate_mail(
+            cursor, uid, template_id, ids, context
+        )
+
+    @job(queue=config.get('poweremail_render_queue', 'poweremail'), on_commit=True)
+    def generate_mail_in_background(self, cursor, uid, template_id, ids, context=None):
+        return super(PoweremailTemplates, self).generate_mail(
+            cursor, uid, template_id, ids, context
+        )
+
+    def generate_mail(self, cursor, uid, template_id, ids, context=None):
+        priority = self.read(cursor, uid, template_id, ['def_priority'])['def_priority']
+        if priority == '2':
+            method = getattr(self, 'generate_mail_in_background_at_front')
+        else:
+            method = getattr(self, 'generate_mail_in_background')
+        return method(cursor, uid, template_id, ids, context)
+
+
+PoweremailTemplates()


### PR DESCRIPTION
Add `generate_mail` in background using queues. Depending on the priority of the template the job will be add at front of the queue (High priority) or not (Normal, Low priority)